### PR TITLE
Fix CI for frontend/backend directories

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,6 +26,24 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm ci
-    - run: npm run build --if-present
-    - run: npm test
+        cache-dependency-path: |
+          backend/package-lock.json
+          frontend/package-lock.json
+    - name: Install backend dependencies
+      run: npm ci
+      working-directory: backend
+    - name: Build backend
+      run: npm run build --if-present
+      working-directory: backend
+    - name: Test backend
+      run: npm test
+      working-directory: backend
+    - name: Install frontend dependencies
+      run: npm ci
+      working-directory: frontend
+    - name: Build frontend
+      run: npm run build --if-present
+      working-directory: frontend
+    - name: Test frontend
+      run: npm test
+      working-directory: frontend


### PR DESCRIPTION
## Summary
- run CI steps separately for backend and frontend
- specify cache dependency paths for both lock files

## Testing
- `npm test --silent` *(fails: `react-scripts: not found`)*
- `npm test --silent` in backend

------
https://chatgpt.com/codex/tasks/task_e_6855dd9978548324a14cb90fbd5fd1c6